### PR TITLE
Update table text colors for better readability.

### DIFF
--- a/FitFileExplorer/src/FITSelectionContext.swift
+++ b/FitFileExplorer/src/FITSelectionContext.swift
@@ -414,7 +414,7 @@ class FITSelectionContext {
         paragraphStyle.lineBreakMode = NSLineBreakMode.byTruncatingMiddle
         
         let attr = [ NSAttributedString.Key.font:NSFont.systemFont(ofSize: 12.0),
-                     NSAttributedString.Key.foregroundColor:NSColor.textColor,
+                     NSAttributedString.Key.foregroundColor:NSColor.labelColor,
                      NSAttributedString.Key.paragraphStyle: paragraphStyle]
 
         return NSAttributedString(attr, with: display)
@@ -426,8 +426,8 @@ class FITSelectionContext {
         let paragraphStyle = NSMutableParagraphStyle()
         paragraphStyle.lineBreakMode = NSLineBreakMode.byTruncatingMiddle
         
-        let disabledLabelColor = NSColor.disabledControlTextColor
-        let highlightLabelColor = NSColor.textColor
+        let disabledLabelColor = NSColor.tertiaryLabelColor
+        let highlightLabelColor = NSColor.labelColor
         
         var attr = [ NSAttributedString.Key.font:NSFont.systemFont(ofSize: 12.0),
                      NSAttributedString.Key.foregroundColor:highlightLabelColor,


### PR DESCRIPTION
Using `labelColor` instead of `textColor` makes sure that macOS automatically inverts the text color in table views when a row is selected. This makes selected rows easier to read. Example:

**New:**

<img width="1356" alt="Screenshot 2025-01-02 at 14 13 59" src="https://github.com/user-attachments/assets/3568ac5e-88a2-45b1-bbb0-fb133fbd7e57" />


**Old:**

<img width="1356" alt="Screenshot 2025-01-02 at 14 10 43" src="https://github.com/user-attachments/assets/1ed2c932-6c83-4048-970c-544757e687a9" />
